### PR TITLE
Fix `yarn test-e2e` and testcafe for single package.json structure

### DIFF
--- a/.testcafe-electron-rc
+++ b/.testcafe-electron-rc
@@ -1,0 +1,4 @@
+{
+  "mainWindowUrl": "./app/app.html",
+  "appPath": "."
+}

--- a/app/.testcafe-electron-rc
+++ b/app/.testcafe-electron-rc
@@ -1,4 +1,0 @@
-{
-  "mainWindowUrl": "./app.html",
-  "appPath": "."
-}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test": "cross-env NODE_ENV=test BABEL_DISABLE_CACHE=1 node --trace-warnings -r babel-register ./internals/scripts/RunTests.js",
     "test-all": "yarn lint && yarn flow && yarn build && yarn test && yarn build-e2e && yarn test-e2e",
     "test-e2e": "node -r babel-register ./internals/scripts/CheckBuiltsExist.js && cross-env NODE_ENV=test testcafe electron:./app ./test/e2e/HomePage.e2e.js",
-    "test-e2e-live": "node -r babel-register ./internals/scripts/CheckBuiltsExist.js && cross-env NODE_ENV=test testcafe-live electron:./app ./test/e2e/HomePage.e2e.js",
+    "test-e2e-live": "node -r babel-register ./internals/scripts/CheckBuiltsExist.js && cross-env NODE_ENV=test testcafe-live electron:./ ./test/e2e/HomePage.e2e.js",
     "test-watch": "yarn test --watch"
   },
   "browserslist": "electron 1.6",


### PR DESCRIPTION
We're attempting to go to a single package.json structure, but the
testcafe setup was still implicitly referencing app/node_modules. This
adjusts testcafe so that it finds the electron browser (provided by
testcafe-browser-provider-electron).

Please double check this. I'm not familiar with testcafe, I just
messed with paths until I got the tests passing.